### PR TITLE
Fixed ImGui throwing two errors

### DIFF
--- a/src/engine/graphics/gui.cpp
+++ b/src/engine/graphics/gui.cpp
@@ -134,7 +134,7 @@ namespace Graphics
 
 		ImGui::DockSpaceOverViewport(ImGui::GetMainViewport(), ImGuiDockNodeFlags_PassthruCentralNode);
 
-		ImGui::End();
+		//ImGui::End();
 
 		RenderTopBar();
 

--- a/src/engine/graphics/render.cpp
+++ b/src/engine/graphics/render.cpp
@@ -52,13 +52,13 @@ namespace Graphics
 
 	void Render::RenderSetup()
 	{
-		Input::InputSetup();
-
 		Render::GLFWSetup();
 		Render::WindowSetup();
 		Render::GladSetup();
 
 		GUI::GetInstance().Initialize();
+
+		Input::InputSetup();
 
 		Render::ContentSetup();
 


### PR DESCRIPTION
There are two errors at runtime
First: 
Cannot call ImGui::GetIO()  (in the function InputSetup() in file input.cpp) because there's not context set. So Input::InputSetup() should be called after ImGui::CreateContext() is called - it also set the context as current.

Second:
error: End is getting called too many times because of ImGui::End() (in function GUI::Render() in file gui.cpp)

Correct me if I am missing something but I had to make these changes for it to work correctly. :)