### PR TITLE
added debug callback

### DIFF
--- a/Engine/src/core/core.cpp
+++ b/Engine/src/core/core.cpp
@@ -352,6 +352,7 @@ namespace Core
 		}
 		//otherwise load first scene
 		else SceneFile::LoadScene(scenesPath + "\\Scene1\\scene.txt");
+
 	}
 
 	void Engine::RunEngine()

--- a/Engine/src/graphics/gui/gui_floatingdebugmenu.cpp
+++ b/Engine/src/graphics/gui/gui_floatingdebugmenu.cpp
@@ -207,12 +207,11 @@ namespace Graphics::GUI
 		}
 	   ImGui::SeparatorText("GPU Info");
       ImGui::Text("GPU Vendor : %s", glGetString(GL_VENDOR));
-      ImGui::Text("GPU : %s", glGetString(GL_RENDERER))ImGui::SeparatorText("Librarys");
-            
+      ImGui::Text("GPU : %s", glGetString(GL_RENDERER))
+
+      ImGui::SeparatorText("Librarys");      
       ImGui::Text("OpenGL Version : %s", glGetString(GL_VERSION));
       ImGui::Text("GLFW Version : %s", glfwGetVersionString());
-      ImGui::Text("Operating System : %s", os);
-      ImGui::Text("Compiled With GCC Version : C = %d, C++ = %d", __GNUC__, __GNUG__);
             
       ImGui::SeparatorText("Window");
       int w,h;

--- a/Engine/src/graphics/gui/gui_floatingdebugmenu.cpp
+++ b/Engine/src/graphics/gui/gui_floatingdebugmenu.cpp
@@ -56,7 +56,6 @@ namespace Graphics::GUI
 		//
 		// GENERAL
 		//
-
 		ImGui::Text("FPS: %.2f", TimeManager::displayedFPS);
 
 		string strObjectsCount = "Objects: " + to_string(objectsCount);
@@ -206,7 +205,37 @@ namespace Graphics::GUI
 			ConfigFile::SetValue("grid_maxDistance", to_string(gridMaxDistance));
 			if (!SceneFile::unsavedChanges) Render::SetWindowNameAsUnsaved(true);
 		}
-	}
+	   ImGui::SeparatorText("GPU Info");
+      ImGui::Text("GPU Vendor : %s", glGetString(GL_VENDOR));
+      ImGui::Text("GPU : %s", glGetString(GL_RENDERER))ImGui::SeparatorText("Librarys");
+            
+      ImGui::Text("OpenGL Version : %s", glGetString(GL_VERSION));
+      ImGui::Text("GLFW Version : %s", glfwGetVersionString());
+      ImGui::Text("Operating System : %s", os);
+      ImGui::Text("Compiled With GCC Version : C = %d, C++ = %d", __GNUC__, __GNUG__);
+            
+      ImGui::SeparatorText("Window");
+      int w,h;
+      glfwGetWindowSize(window, &w, &h);
+      ImGui::Text("Window Width : %i", w);
+      ImGui::Text("Window Height : %i", h);
+      
+      ImGui::SeparatorText("Framebuffer");
+      int ret;
+      glGetFramebufferAttachmentParameteriv(GL_FRAMEBUFFER, GL_FRONT, GL_FRAMEBUFFER_ATTACHMENT_RED_SIZE, &ret);
+      ImGui::Text("Red Bit Size : %d", ret);
+      glGetFramebufferAttachmentParameteriv(GL_FRAMEBUFFER, GL_FRONT, GL_FRAMEBUFFER_ATTACHMENT_GREEN_SIZE, &ret);
+      ImGui::Text("Green Bit Size : %d", ret);
+      glGetFramebufferAttachmentParameteriv(GL_FRAMEBUFFER, GL_FRONT, GL_FRAMEBUFFER_ATTACHMENT_BLUE_SIZE, &ret);
+      ImGui::Text("Blue Bit Size : %d", ret);
+      glGetFramebufferAttachmentParameteriv(GL_FRAMEBUFFER, GL_FRONT, GL_FRAMEBUFFER_ATTACHMENT_ALPHA_SIZE, &ret);
+      ImGui::Text("Alpha Bit Size : %d", ret);
+      glGetFramebufferAttachmentParameteriv(GL_FRAMEBUFFER, GL_DEPTH, GL_FRAMEBUFFER_ATTACHMENT_DEPTH_SIZE, &ret);
+      ImGui::Text("Depth Bit Size : %d", ret);
+      glGetFramebufferAttachmentParameteriv(GL_FRAMEBUFFER, GL_STENCIL, GL_FRAMEBUFFER_ATTACHMENT_STENCIL_SIZE, &ret);
+      ImGui::Text("Stencil Bit Size : %d", ret);;
+
+   }
 
 	void GUIFloatingDebugMenu::UpdateCounts()
 	{

--- a/Engine/src/graphics/render.cpp
+++ b/Engine/src/graphics/render.cpp
@@ -61,6 +61,19 @@ namespace Graphics
 {
 	Camera Render::camera(Render::window, 0.05f);
 
+   void GLAPIENTRY GLErrorCallback( GLenum source,
+                                    GLenum type,
+                                    GLuint id,
+                                    GLenum severity,
+                                    GLsizei length,
+                                    const GLchar* message,
+                                    const void* userParam)
+   {
+#if 1 // replace this with however you check that your compiling with DEBUG, or make it an int that you can change in the editor or something like that 
+      std::cout << "GL ERROR : TYPE " << type <<" : SEVERITY " << severity << " : MESSAGE " << message << "\n"; 
+#endif 
+   }
+
 	void Render::RenderSetup()
 	{
 		GLFWSetup();
@@ -174,6 +187,17 @@ namespace Graphics
 		glEnable(GL_BLEND);
 		//set blending function
 		glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+
+      //get gl version for debug callback
+      int minor, major;
+      glGetIntegerv(GL_MINOR_VERSION, &minor);
+      glGetIntegerv(GL_MAJOR_VERSION, &major);
+      //enable debug callback if opengl version is high enough
+      if (major >= 4 && minor >= 3) {
+         glEnable(GL_DEBUG_OUTPUT);
+         glDebugMessageCallbak(MessageCallback, 0);
+      }
+
 
 		Grid::InitializeGrid();
 

--- a/Engine/src/graphics/render.cpp
+++ b/Engine/src/graphics/render.cpp
@@ -195,7 +195,7 @@ namespace Graphics
       //enable debug callback if opengl version is high enough
       if (major >= 4 && minor >= 3) {
          glEnable(GL_DEBUG_OUTPUT);
-         glDebugMessageCallbak(MessageCallback, 0);
+         glDebugMessageCallback(MessageCallback, 0);
       }
 
 


### PR DESCRIPTION
added opengl debug callback. whenever an error is detected by opengl, the console will get spammed with errors. i would recommend putting the printing of it behind a `#ifdef DEBUG` or something similar, or even a toggle in the editor